### PR TITLE
Feat/#57 스트리밍 서버 접속 종료 시 임시 음원 파일 제거

### DIFF
--- a/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/constant/StreamingConstant.kt
+++ b/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/constant/StreamingConstant.kt
@@ -1,0 +1,6 @@
+package com.lalala.streaming.constant
+
+object StreamingConstant {
+    const val TEMP_FOLDER = "temp/"           // 임시 음원 파일 저장 폴더
+    const val TRIM_DURATION_SEC = 3           // 파일 자르기 기준 시간 (초)
+}

--- a/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/handler/StreamingHandler.kt
+++ b/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/handler/StreamingHandler.kt
@@ -100,7 +100,7 @@ class StreamingHandler(
     fun sendPlayTime(session: WebSocketSession, musicId: String) {
         // 음원 서버에서 파일 주소 조회
         val music = getMusic(session, musicId)
-        music?.playTime.let { session.sendMessage(TextMessage("$it")) }
+        music.playTime.let { session.sendMessage(TextMessage("$it")) }
     }
 
     fun startStream(session: WebSocketSession, musicId: String, startTime: String) {

--- a/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/handler/StreamingHandler.kt
+++ b/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/handler/StreamingHandler.kt
@@ -111,7 +111,9 @@ class StreamingHandler(
         // 파일 서버에서 파일 다운로드
         downloadMusic(session, fileName)
 
-        val result = ffProbe.probe("${session.id}.mp3")
+        val mediaFile = File("${StreamingConstant.TEMP_FOLDER}/${session.id}.mp3")
+
+        val result = ffProbe.probe(mediaFile.path)
         val format = result.getFormat()
         val duration = format.duration
 
@@ -122,7 +124,7 @@ class StreamingHandler(
         val processBuilder = ProcessBuilder()
         processBuilder.directory(File(System.getProperty("user.dir")));
         processBuilder.command(
-            ffMpeg.path, "-y", "-i", "${StreamingConstant.TEMP_FOLDER}/${session.id}.mp3",
+            ffMpeg.path, "-y", "-i", mediaFile.path,
             "-ss", startTime, "-f", "segment", "-segment_time", "${StreamingConstant.TRIM_DURATION_SEC}",
             "${StreamingConstant.TEMP_FOLDER}/${session.id}-%d.flac"
         )
@@ -160,13 +162,12 @@ class StreamingHandler(
             session.sendMessage(BinaryMessage(ByteArray(0), true))
 
             splitFile.delete()
-            File(StreamingConstant.TEMP_FOLDER, "${session.id}-${i}.flac").delete()
 
             // 다음 전달까지 대기
             Thread.sleep(100);
         }
 
-        File(StreamingConstant.TEMP_FOLDER, "${session.id}.mp3").delete()
+        mediaFile.delete()
     }
 
     fun downloadMusic(session: WebSocketSession, fileName: String) {

--- a/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/handler/StreamingHandler.kt
+++ b/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/handler/StreamingHandler.kt
@@ -30,9 +30,7 @@ class StreamingHandler(
     @Qualifier("storageClient")
     private val storageClient: RestClient,
 ) : TextWebSocketHandler() {
-    // TODO: 레디스 연결하여 노래 끝났는지 확인
     // TODO: 다음 트랙 변화 이벤트 추가
-    // TODO: 연결 끊어졌을 때 해당 세션 파일 찾아서 삭제
 
     private val logger = KotlinLogging.logger {}
 

--- a/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/handler/StreamingHandler.kt
+++ b/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/handler/StreamingHandler.kt
@@ -63,16 +63,21 @@ class StreamingHandler(
         val command = payload.split("/")[0]
         val commandType = Command.entries.find { it.value == command } ?: throw RuntimeException()
 
-        when (commandType) {
-            Command.GET -> {
-                val musicId = payload.split("/")[1]
-                sendPlayTime(session, musicId)
+        try {
+            when (commandType) {
+                Command.GET -> {
+                    val musicId = payload.split("/")[1]
+                    sendPlayTime(session, musicId)
+                }
+
+                Command.STREAM -> {
+                    val musicId = payload.split("/")[1]
+                    val startTime = payload.split("/")[2]
+                    startStream(session, musicId, startTime)
+                }
             }
-            Command.STREAM -> {
-                val musicId = payload.split("/")[1]
-                val startTime = payload.split("/")[2]
-                startStream(session, musicId, startTime)
-            }
+        } catch (err: Exception) {
+            afterConnectionClosed(session, CloseStatus.GOING_AWAY)
         }
     }
 

--- a/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/listener/TempFileDeleteListener.kt
+++ b/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/listener/TempFileDeleteListener.kt
@@ -1,0 +1,23 @@
+package com.lalala.streaming.listener
+
+import com.lalala.streaming.constant.StreamingConstant
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import java.io.File
+
+@Component
+class TempFileDeleteListener {
+    private val logger = KotlinLogging.logger {}
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun DeleteTempFilesAfterStartUp() {
+        File(StreamingConstant.TEMP_FOLDER)
+            .walkTopDown()
+            .maxDepth(1)
+            .forEach(File::delete)
+
+        logger.info { "임시 폴더의 모든 음원 파일을 청소했습니다." }
+    }
+}

--- a/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/listener/TempFileDeleteListener.kt
+++ b/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/listener/TempFileDeleteListener.kt
@@ -13,9 +13,12 @@ class TempFileDeleteListener {
 
     @EventListener(ApplicationReadyEvent::class)
     fun DeleteTempFilesAfterStartUp() {
+        File(StreamingConstant.TEMP_FOLDER).mkdir()
+
         File(StreamingConstant.TEMP_FOLDER)
             .walkTopDown()
             .maxDepth(1)
+            .filter(File::isFile)
             .forEach(File::delete)
 
         logger.info { "임시 폴더의 모든 음원 파일을 청소했습니다." }


### PR DESCRIPTION
## Related Issue

close #57 

## Changes

- 서버 시작 시 임시 음원 저장 폴더 초기화
- 연결 끊길 시 임시 음원 파일 삭제
- 예외로 통신 끊길 시 연결 끊긴 로직 호출
- 스트리밍 상수 별도 파일로 분리
- 기타 코드 리팩터링

## Screenshots

<!-- PR의 변경사항을 보여주는 스크린샷. 필요시 추가하세요. -->

## To Reviewer

<!-- 리뷰어에게 별도로 전달하고 싶은 내용이 있다면 입력하세요. -->

## Additional Context(optional)

<!-- 추가적인 문맥: 레퍼런스, 종속성 변경 등 PR과는 직접적으로 관련되지 않은 정보를 입력하세요. -->

- 핸들러 자체에서 연결 / 종료 이벤트를 오버라이딩할 수 있습니다.

## How Has This Been Tested?

<!-- PR이 동작하는지 확인하기 위한 테스트 방법 및 케이스를 상세하게 설명해주세요. -->

## Checklist

<!-- PR 등록 전 확인해 주세요! -->

- [ ] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [ ] PR에 대해 구체적으로 설명이 되어있는가
