### PR TITLE
Feat/#52 음원 업로드 기능을 추가합니다.

### DIFF
--- a/.github/workflows/dockerhub-push-go.yml
+++ b/.github/workflows/dockerhub-push-go.yml
@@ -1,0 +1,39 @@
+name: Docker Hub Push for go
+
+on:
+  push:
+    branches:
+      - "stroage/develop"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set Environment Variables
+        run: |
+          BRANCH_NAME=$(echo $GITHUB_REF | awk -F'/' '{print $3}')
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Build and Push Docker Image
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+
+        run: |
+          if [ -n "$BRANCH_NAME" ]; then
+            DOCKERFILE_DIR="src/backend/$BRANCH_NAME-server"
+          else
+            echo "Failed to extract branch name from GITHUB_REF."
+            exit 1
+          fi
+
+          cd $DOCKERFILE_DIR
+          docker run --privileged --rm tonistiigi/binfmt --install all
+          docker buildx create --use
+          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+          docker buildx build --platform=linux/amd64,linux/arm64 -t $DOCKER_USERNAME/$BRANCH_NAME:latest . --push

--- a/.github/workflows/dockerhub-push-nodejs.yml
+++ b/.github/workflows/dockerhub-push-nodejs.yml
@@ -1,9 +1,9 @@
-name: Docker Hub Push
+name: Docker Hub Push for nodejs
 
 on:
   push:
     branches:
-      - "**/develop"
+      - "music-uploader/develop"
 
 jobs:
   build-and-push:

--- a/.github/workflows/dockerhub-push-python.yml
+++ b/.github/workflows/dockerhub-push-python.yml
@@ -1,0 +1,39 @@
+name: Docker Hub Push for python
+
+on:
+  push:
+    branches:
+      - "stroage/develop"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set Environment Variables
+        run: |
+          BRANCH_NAME=$(echo $GITHUB_REF | awk -F'/' '{print $3}')
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Build and Push Docker Image
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+
+        run: |
+          if [ -n "$BRANCH_NAME" ]; then
+            DOCKERFILE_DIR="src/backend/$BRANCH_NAME-server"
+          else
+            echo "Failed to extract branch name from GITHUB_REF."
+            exit 1
+          fi
+
+          cd $DOCKERFILE_DIR
+          docker run --privileged --rm tonistiigi/binfmt --install all
+          docker buildx create --use
+          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+          docker buildx build --platform=linux/amd64,linux/arm64 -t $DOCKER_USERNAME/$BRANCH_NAME:latest . --push

--- a/.github/workflows/dockerhub-push-springboot-17.yml
+++ b/.github/workflows/dockerhub-push-springboot-17.yml
@@ -1,0 +1,72 @@
+name: Docker Hub Push for SpringBoot 17
+
+on:
+  push:
+    branches:
+      - "music/develop"
+      - "streaming/develop"
+      - "storage/develop"
+      - "alarm/develop"
+      - "user/develop"
+      - "auth/develop"
+      - "chatting/develop"
+      - "feed/develop"
+      - "playlist/develop"
+      - "gateway/develop"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set Environment Variables
+        run: |
+          BRANCH_NAME=$(echo $GITHUB_REF | awk -F'/' '{print $3}')
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x src/backend/${{ env.BRANCH_NAME }}-server/gradlew
+
+      - name: Build with Gradle
+        run: |
+          cd src/backend/${{ env.BRANCH_NAME }}-server
+          ./gradlew clean build -x test
+
+      - name: Build and Push Docker Image
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+
+        run: |
+          if [ -n "$BRANCH_NAME" ]; then
+            DOCKERFILE_DIR="src/backend/$BRANCH_NAME-server"
+          else
+            echo "Failed to extract branch name from GITHUB_REF."
+            exit 1
+          fi
+
+          cd $DOCKERFILE_DIR
+          docker run --privileged --rm tonistiigi/binfmt --install all
+          docker buildx create --use
+          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+          docker buildx build --platform=linux/amd64,linux/arm64 -t $DOCKER_USERNAME/$BRANCH_NAME:latest . --push

--- a/.github/workflows/dockerhub-push-springboot-21.yml
+++ b/.github/workflows/dockerhub-push-springboot-21.yml
@@ -1,0 +1,63 @@
+name: Docker Hub Push for SpringBoot 21
+
+on:
+  push:
+    branches:
+      - "chart/develop"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set Environment Variables
+        run: |
+          BRANCH_NAME=$(echo $GITHUB_REF | awk -F'/' '{print $3}')
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x src/backend/${{ env.BRANCH_NAME }}-server/gradlew
+
+      - name: Build with Gradle
+        run: |
+          cd src/backend/${{ env.BRANCH_NAME }}-server
+          ./gradlew clean build -x test
+
+      - name: Build and Push Docker Image
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
+
+        run: |
+          if [ -n "$BRANCH_NAME" ]; then
+            DOCKERFILE_DIR="src/backend/$BRANCH_NAME-server"
+          else
+            echo "Failed to extract branch name from GITHUB_REF."
+            exit 1
+          fi
+
+          cd $DOCKERFILE_DIR
+          docker run --privileged --rm tonistiigi/binfmt --install all
+          docker buildx create --use
+          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+          docker buildx build --platform=linux/amd64,linux/arm64 -t $DOCKER_USERNAME/$BRANCH_NAME:latest . --push

--- a/src/backend/music-server/Dockerfile
+++ b/src/backend/music-server/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-jdk-slim
 CMD ["./gradlew", "build"]
 ARG JAR_FILE_PATH=music-api/build/libs/*.jar
+ARG DOCKER_YML_FILE=music-api/src/main/resources/application.yml
 COPY ${JAR_FILE_PATH} app.jar
+COPY ${DOCKER_YML_FILE} application.yml
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/backend/music-server/build.gradle
+++ b/src/backend/music-server/build.gradle
@@ -2,6 +2,9 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.1'
 	id 'io.spring.dependency-management' version '1.1.4'
+
+	// Lint
+	id("com.diffplug.spotless") version("6.11.0") apply false
 }
 
 repositories {
@@ -19,6 +22,7 @@ subprojects {
 	apply plugin: 'java'
 	apply plugin: 'org.springframework.boot'
 	apply plugin: 'io.spring.dependency-management'
+	apply plugin: 'com.diffplug.spotless'
 
 	group = 'com.lalala'
 	version = '0.0.1-SNAPSHOT'
@@ -51,4 +55,30 @@ subprojects {
 		useJUnitPlatform()
 	}
 
+	spotless {
+		java {
+			// import 순서 정의
+			importOrder(
+					"java",
+					"javax",
+					"lombok",
+					"org.springframework",
+					"",
+					"\\#",
+					"org.junit",
+					"\\#org.junit",
+			)
+			// 사용하지 않는 import 제거
+			removeUnusedImports()
+			// 구글 자바 포맷 적용
+			googleJavaFormat()
+			// Indent
+			indentWithTabs(2)
+			indentWithSpaces(4)
+			// 공백 제거
+			trimTrailingWhitespace()
+			// 끝부분 New Line 처리
+			endWithNewline()
+		}
+	}
 }

--- a/src/backend/music-server/build.gradle
+++ b/src/backend/music-server/build.gradle
@@ -57,6 +57,16 @@ subprojects {
 
 	spotless {
 		java {
+			googleJavaFormat()			// 구글 자바 포맷 적용
+
+			removeUnusedImports()       // 사용하지 않는 import 제거
+			trimTrailingWhitespace() 	// 공백 제거
+			endWithNewline() 			// 끝부분 New Line 처리
+
+			// Indentation
+			indentWithTabs(2)
+			indentWithSpaces(4)
+
 			// import 순서 정의
 			importOrder(
 					"java",
@@ -68,17 +78,6 @@ subprojects {
 					"org.junit",
 					"\\#org.junit",
 			)
-			// 사용하지 않는 import 제거
-			removeUnusedImports()
-			// 구글 자바 포맷 적용
-			googleJavaFormat()
-			// Indent
-			indentWithTabs(2)
-			indentWithSpaces(4)
-			// 공백 제거
-			trimTrailingWhitespace()
-			// 끝부분 New Line 처리
-			endWithNewline()
 		}
 	}
 }

--- a/src/backend/music-server/docker-compose.yml
+++ b/src/backend/music-server/docker-compose.yml
@@ -1,19 +1,27 @@
 version: '3.9'
 services:
-  app:
+  music-app:
     build:
       context: .
       dockerfile: Dockerfile
     restart: always
+    ports:
+      - 24000:24000
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://music-mysql:3306/music?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: admin
     depends_on:
-      - mysql
+      - music-mysql
+    networks:
+      - lalala-network
 
-  mysql:
+  music-mysql:
     image: mysql:8.2.0
     container_name: music-db
     restart: always
     ports:
-      - 9306:3306
+      - 24100:3306
     environment:
       MYSQL_ROOT_PASSWORD: admin
       MYSQL_DATABASE: music
@@ -24,10 +32,19 @@ services:
     volumes:
       - ./.docker/mysql/:/var/lib/mysql
       - ./infra/:/docker-entrypoint-initdb.d
+    networks:
+      - lalala-network
 
-  adminer:
+  music-adminer:
     image: adminer
     container_name: music-adminer
     restart: always
     ports:
-      - 8900:8080
+      - 24200:8080
+    networks:
+      - lalala-network
+
+networks:
+  lalala-network:
+    driver: bridge
+    external: true

--- a/src/backend/music-server/music-api/build.gradle
+++ b/src/backend/music-server/music-api/build.gradle
@@ -8,4 +8,6 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    implementation  'com.mpatric:mp3agic:0.9.1'
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/MusicApplication.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/MusicApplication.java
@@ -6,8 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class MusicApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(MusicApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(MusicApplication.class, args);
+    }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/JpaAuditingConfiguration.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/JpaAuditingConfiguration.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-public class JpaAuditingConfiguration {
-}
+public class JpaAuditingConfiguration {}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/MultipartConfig.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/MultipartConfig.java
@@ -1,0 +1,34 @@
+package com.lalala.music.config;
+
+import jakarta.servlet.MultipartConfigElement;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.MultipartConfigFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.multipart.MultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
+
+@Configuration
+public class MultipartConfig {
+    private static final long MB_UNIT = 1024L * 1024L;
+
+    @Value("${file.multipart.maxUploadSizeMB:20}")
+    private long maxUploadSizeMB;
+
+    @Value("${file.multipart.maxUploadSizePerFileMB:20}")
+    private long maxUploadSizePerFileMB;
+
+    @Bean
+    public MultipartResolver multipartResolver() {
+        return new StandardServletMultipartResolver();
+    }
+
+    @Bean
+    public MultipartConfigElement multipartConfigElement() {
+        MultipartConfigFactory factory = new MultipartConfigFactory();
+        factory.setMaxRequestSize(DataSize.ofBytes(maxUploadSizeMB * MB_UNIT));
+        factory.setMaxFileSize(DataSize.ofBytes(maxUploadSizePerFileMB * MB_UNIT));
+        return factory.createMultipartConfig();
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/MultipartConfig.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/MultipartConfig.java
@@ -1,6 +1,5 @@
 package com.lalala.music.config;
 
-import jakarta.servlet.MultipartConfigElement;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.MultipartConfigFactory;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +7,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.unit.DataSize;
 import org.springframework.web.multipart.MultipartResolver;
 import org.springframework.web.multipart.support.StandardServletMultipartResolver;
+
+import jakarta.servlet.MultipartConfigElement;
 
 @Configuration
 public class MultipartConfig {

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/RestClientConfig.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/RestClientConfig.java
@@ -12,8 +12,6 @@ public class RestClientConfig {
 
     @Bean(name = {"uploaderClient"})
     public RestClient restClient() {
-        return RestClient.builder()
-                .baseUrl(uploaderURL)
-                .build();
+        return RestClient.builder().baseUrl(uploaderURL).build();
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/RestClientConfig.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/RestClientConfig.java
@@ -1,0 +1,19 @@
+package com.lalala.music.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+    @Value("${uploader.url:http://localhost:25000}")
+    private String uploaderURL;
+
+    @Bean(name = {"uploaderClient"})
+    public RestClient restClient() {
+        return RestClient.builder()
+                .baseUrl(uploaderURL)
+                .build();
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/SwaggerConfiguration.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/SwaggerConfiguration.java
@@ -1,19 +1,16 @@
 package com.lalala.music.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 
 @Configuration
 public class SwaggerConfiguration {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .info(new Info()
-                        .title("음원 API")
-                        .description("음원 API를 제공합니다.")
-                        .version("0.0.1")
-                );
+                .info(new Info().title("음원 API").description("음원 API를 제공합니다.").version("0.0.1"));
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/WebConfiguration.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/config/WebConfiguration.java
@@ -10,8 +10,6 @@ public class WebConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins("*")
-                .maxAge(MAX_AGE);
+        registry.addMapping("/**").allowedOrigins("*").maxAge(MAX_AGE);
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/controller/AlbumController.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/controller/AlbumController.java
@@ -1,12 +1,10 @@
 package com.lalala.music.controller;
 
-import com.lalala.music.dto.AlbumDTO;
-import com.lalala.music.dto.AlbumDetailDTO;
-import com.lalala.music.dto.CreateAlbumRequestDTO;
-import com.lalala.music.dto.UpdateAlbumRequestDTO;
-import com.lalala.music.service.AlbumService;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +16,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.lalala.music.dto.AlbumDTO;
+import com.lalala.music.dto.AlbumDetailDTO;
+import com.lalala.music.dto.CreateAlbumRequestDTO;
+import com.lalala.music.dto.SuccessResponse;
+import com.lalala.music.dto.UpdateAlbumRequestDTO;
+import com.lalala.music.service.AlbumService;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/albums")
@@ -25,38 +30,36 @@ public class AlbumController {
     private final AlbumService service;
 
     @PostMapping
-    public ResponseEntity<AlbumDetailDTO> createAlbum(@RequestBody CreateAlbumRequestDTO request) {
+    public ResponseEntity<SuccessResponse<AlbumDetailDTO>> createAlbum(
+            @RequestBody CreateAlbumRequestDTO request) {
         AlbumDetailDTO album = service.createAlbum(request);
-        return ResponseEntity.ok(album);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "앨범을 생성했습니다.", album));
     }
 
     @GetMapping
-    public ResponseEntity<List<AlbumDTO>> readAlbums(
+    public ResponseEntity<SuccessResponse<List<AlbumDTO>>> readAlbums(
             @RequestParam(required = false, defaultValue = "0", name = "page") int page,
-            @RequestParam(required = false, defaultValue = "50", name = "size") int pageSize
-    ) {
+            @RequestParam(required = false, defaultValue = "50", name = "size") int pageSize) {
         List<AlbumDTO> albums = service.getAlbums(page, pageSize);
-        return ResponseEntity.ok(albums);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "앨범 목록을 조회했습니다.", albums));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<AlbumDetailDTO> readAlbum(@PathVariable("id") Long id) {
+    public ResponseEntity<SuccessResponse<AlbumDetailDTO>> readAlbum(@PathVariable("id") Long id) {
         AlbumDetailDTO album = service.getAlbum(id);
-        return ResponseEntity.ok(album);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "앨범을 조회했습니다.", album));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<AlbumDetailDTO> updateAlbum(
-            @PathVariable("id") Long id,
-            @RequestBody UpdateAlbumRequestDTO request
-        ) {
+    public ResponseEntity<SuccessResponse<AlbumDetailDTO>> updateAlbum(
+            @PathVariable("id") Long id, @RequestBody UpdateAlbumRequestDTO request) {
         AlbumDetailDTO album = service.updateAlbum(id, request);
-        return ResponseEntity.ok(album);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "앨범을 수정했습니다.", album));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<AlbumDetailDTO> deleteAlbum(@PathVariable("id") Long id) {
+    public ResponseEntity<SuccessResponse<AlbumDetailDTO>> deleteAlbum(@PathVariable("id") Long id) {
         AlbumDetailDTO album = service.deleteAlbum(id);
-        return ResponseEntity.ok(album);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "앨범을 삭제했습니다.", album));
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/controller/ArtistController.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/controller/ArtistController.java
@@ -1,12 +1,10 @@
 package com.lalala.music.controller;
 
-import com.lalala.music.dto.ArtistDTO;
-import com.lalala.music.dto.ArtistDetailDTO;
-import com.lalala.music.dto.CreateArtistRequestDTO;
-import com.lalala.music.dto.UpdateArtistRequestDTO;
-import com.lalala.music.service.ArtistService;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +16,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.lalala.music.dto.ArtistDTO;
+import com.lalala.music.dto.ArtistDetailDTO;
+import com.lalala.music.dto.CreateArtistRequestDTO;
+import com.lalala.music.dto.SuccessResponse;
+import com.lalala.music.dto.UpdateArtistRequestDTO;
+import com.lalala.music.service.ArtistService;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/artists")
@@ -25,38 +30,36 @@ public class ArtistController {
     private final ArtistService service;
 
     @PostMapping
-    public ResponseEntity<ArtistDTO> createArtist(@RequestBody CreateArtistRequestDTO request) {
+    public ResponseEntity<SuccessResponse<ArtistDTO>> createArtist(
+            @RequestBody CreateArtistRequestDTO request) {
         ArtistDTO artist = service.createArtist(request);
-        return ResponseEntity.ok(artist);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "아티스트를 생성했습니다.", artist));
     }
 
     @GetMapping
-    public ResponseEntity<List<ArtistDTO>> readArtists(
+    public ResponseEntity<SuccessResponse<List<ArtistDTO>>> readArtists(
             @RequestParam(required = false, defaultValue = "0", name = "page") int page,
-            @RequestParam(required = false, defaultValue = "50", name = "size") int pageSize
-    ) {
+            @RequestParam(required = false, defaultValue = "50", name = "size") int pageSize) {
         List<ArtistDTO> artists = service.getArtists(page, pageSize);
-        return ResponseEntity.ok(artists);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "아티스트 목록을 조회했습니다.", artists));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ArtistDetailDTO> readArtist(@PathVariable("id") Long id) {
+    public ResponseEntity<SuccessResponse<ArtistDetailDTO>> readArtist(@PathVariable("id") Long id) {
         ArtistDetailDTO artist = service.getArtist(id);
-        return ResponseEntity.ok(artist);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "아티스트를 조회했습니다.", artist));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ArtistDTO> updateArtist(
-            @PathVariable("id") Long id,
-            @RequestBody UpdateArtistRequestDTO request
-    ) {
+    public ResponseEntity<SuccessResponse<ArtistDTO>> updateArtist(
+            @PathVariable("id") Long id, @RequestBody UpdateArtistRequestDTO request) {
         ArtistDTO artist = service.updateArtist(id, request);
-        return ResponseEntity.ok(artist);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "아티스트를 수정했습니다.", artist));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ArtistDTO> deleteArtist(@PathVariable("id") Long id) {
+    public ResponseEntity<SuccessResponse<ArtistDTO>> deleteArtist(@PathVariable("id") Long id) {
         ArtistDTO artist = service.deleteArtist(id);
-        return ResponseEntity.ok(artist);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "아티스트를 삭제했습니다.", artist));
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/controller/MusicController.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/controller/MusicController.java
@@ -1,12 +1,10 @@
 package com.lalala.music.controller;
 
-import com.lalala.music.dto.CreateMusicRequestDTO;
-import com.lalala.music.dto.MusicDTO;
-import com.lalala.music.dto.MusicDetailDTO;
-import com.lalala.music.dto.UpdateMusicRequestDTO;
-import com.lalala.music.service.MusicService;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,9 +22,6 @@ import com.lalala.music.dto.MusicDTO;
 import com.lalala.music.dto.MusicDetailDTO;
 import com.lalala.music.dto.SuccessResponse;
 import com.lalala.music.dto.UpdateMusicRequestDTO;
-import com.lalala.music.service.AlbumService;
-import com.lalala.music.service.ArtistService;
-import com.lalala.music.service.MusicExtractorService;
 import com.lalala.music.service.MusicService;
 import com.lalala.music.service.MusicUploaderService;
 
@@ -35,16 +30,15 @@ import com.lalala.music.service.MusicUploaderService;
 @RequestMapping("/api/v1/musics")
 public class MusicController {
     private final MusicService service;
-    private final ArtistService artistService;
-    private final AlbumService albumService;
-
-    private final MusicExtractorService extractorService;
     private final MusicUploaderService uploaderService;
 
     @PostMapping
-    public ResponseEntity<MusicDetailDTO> createMusic(@RequestBody CreateMusicRequestDTO request) {
+    public ResponseEntity<SuccessResponse<MusicDetailDTO>> createMusic(
+            @RequestBody CreateMusicRequestDTO request) {
         MusicDetailDTO music = service.createMusic(request);
-        return ResponseEntity.ok(music);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "음원을 생성했습니다.", music));
+    }
+
     @PostMapping(value = "/upload", consumes = "multipart/form-data")
     public ResponseEntity<SuccessResponse<MusicDetailDTO>> uploadMusic(
             @RequestParam(value = "upload") MultipartFile file) {
@@ -53,32 +47,29 @@ public class MusicController {
     }
 
     @GetMapping
-    public ResponseEntity<List<MusicDTO>> readMusics(
+    public ResponseEntity<SuccessResponse<List<MusicDTO>>> readMusics(
             @RequestParam(required = false, defaultValue = "0", name = "page") int page,
-            @RequestParam(required = false, defaultValue = "50", name = "size") int pageSize
-    ) {
+            @RequestParam(required = false, defaultValue = "50", name = "size") int pageSize) {
         List<MusicDTO> musics = service.getMusics(page, pageSize);
-        return ResponseEntity.ok(musics);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "음원을 조회했습니다.", musics));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<MusicDetailDTO> readMusic(@PathVariable("id") Long id) {
+    public ResponseEntity<SuccessResponse<MusicDetailDTO>> readMusic(@PathVariable("id") Long id) {
         MusicDetailDTO music = service.getMusic(id);
-        return ResponseEntity.ok(music);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "음원을 업로드했습니다.", music));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<MusicDetailDTO> updateMusic(
-            @PathVariable("id") Long id,
-            @RequestBody UpdateMusicRequestDTO request
-    ) {
+    public ResponseEntity<SuccessResponse<MusicDetailDTO>> updateMusic(
+            @PathVariable("id") Long id, @RequestBody UpdateMusicRequestDTO request) {
         MusicDetailDTO music = service.updateMusic(id, request);
-        return ResponseEntity.ok(music);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "음원을 업로드했습니다.", music));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<MusicDetailDTO> deleteMusic(@PathVariable("id") Long id) {
+    public ResponseEntity<SuccessResponse<MusicDetailDTO>> deleteMusic(@PathVariable("id") Long id) {
         MusicDetailDTO music = service.deleteMusic(id);
-        return ResponseEntity.ok(music);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "음원을 업로드했습니다.", music));
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/controller/MusicController.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/controller/MusicController.java
@@ -17,17 +17,39 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.lalala.music.dto.CreateMusicRequestDTO;
+import com.lalala.music.dto.MusicDTO;
+import com.lalala.music.dto.MusicDetailDTO;
+import com.lalala.music.dto.SuccessResponse;
+import com.lalala.music.dto.UpdateMusicRequestDTO;
+import com.lalala.music.service.AlbumService;
+import com.lalala.music.service.ArtistService;
+import com.lalala.music.service.MusicExtractorService;
+import com.lalala.music.service.MusicService;
+import com.lalala.music.service.MusicUploaderService;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/musics")
 public class MusicController {
     private final MusicService service;
+    private final ArtistService artistService;
+    private final AlbumService albumService;
+
+    private final MusicExtractorService extractorService;
+    private final MusicUploaderService uploaderService;
 
     @PostMapping
     public ResponseEntity<MusicDetailDTO> createMusic(@RequestBody CreateMusicRequestDTO request) {
         MusicDetailDTO music = service.createMusic(request);
         return ResponseEntity.ok(music);
+    @PostMapping(value = "/upload", consumes = "multipart/form-data")
+    public ResponseEntity<SuccessResponse<MusicDetailDTO>> uploadMusic(
+            @RequestParam(value = "upload") MultipartFile file) {
+        MusicDetailDTO music = uploaderService.upload(file);
+        return ResponseEntity.ok(SuccessResponse.from(HttpStatus.OK, "음원을 업로드했습니다.", music));
     }
 
     @GetMapping

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/AlbumDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/AlbumDTO.java
@@ -1,13 +1,14 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.AlbumEntity;
-import com.lalala.music.entity.AlbumType;
-import com.lalala.music.entity.ArtistEntity;
 import java.time.LocalDateTime;
-import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import com.lalala.music.entity.AlbumEntity;
+import com.lalala.music.entity.AlbumType;
+import com.lalala.music.entity.ArtistEntity;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -20,17 +21,13 @@ public class AlbumDTO {
 
     private final ArtistDTO artist;
 
-    public static AlbumDTO from(
-            AlbumEntity album,
-            ArtistEntity artist
-    ) {
+    public static AlbumDTO from(AlbumEntity album, ArtistEntity artist) {
         return new AlbumDTO(
                 album.getId(),
                 album.getType(),
                 album.getTitle(),
                 album.getCoverUrl(),
                 album.getReleasedAt(),
-                ArtistDTO.from(artist)
-        );
+                ArtistDTO.from(artist));
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/AlbumDetailDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/AlbumDetailDTO.java
@@ -1,14 +1,16 @@
 package com.lalala.music.dto;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import com.lalala.music.entity.AlbumEntity;
 import com.lalala.music.entity.AlbumType;
 import com.lalala.music.entity.ArtistEntity;
 import com.lalala.music.entity.MusicEntity;
-import java.time.LocalDateTime;
-import java.util.List;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -23,10 +25,7 @@ public class AlbumDetailDTO {
     private final List<MusicDTO> musics;
 
     public static AlbumDetailDTO from(
-            AlbumEntity album,
-            ArtistEntity artist,
-            List<MusicEntity> musics
-    ) {
+            AlbumEntity album, ArtistEntity artist, List<MusicEntity> musics) {
         return new AlbumDetailDTO(
                 album.getId(),
                 album.getType(),
@@ -34,24 +33,10 @@ public class AlbumDetailDTO {
                 album.getCoverUrl(),
                 album.getReleasedAt(),
                 ArtistDTO.from(artist),
-                musics.stream().map(
-                        music -> MusicDTO.from(
-                            music,
-                            album,
-                            artist
-                        )
-                ).toList()
-        );
+                musics.stream().map(music -> MusicDTO.from(music, album, artist)).toList());
     }
 
-    public static AlbumDetailDTO from(
-            AlbumEntity album,
-            ArtistEntity artist
-    ) {
-        return from(
-                album,
-                artist,
-                List.of()
-        );
+    public static AlbumDetailDTO from(AlbumEntity album, ArtistEntity artist) {
+        return from(album, artist, List.of());
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/ArtistDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/ArtistDTO.java
@@ -1,12 +1,14 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.ArtistEntity;
-import com.lalala.music.entity.ArtistType;
-import com.lalala.music.entity.GenderType;
 import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import com.lalala.music.entity.ArtistEntity;
+import com.lalala.music.entity.ArtistType;
+import com.lalala.music.entity.GenderType;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -27,7 +29,6 @@ public final class ArtistDTO {
                 artist.getType(),
                 artist.getAgency(),
                 artist.getCreatedAt(),
-                artist.getUpdatedAt()
-        );
+                artist.getUpdatedAt());
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/ArtistDetailDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/ArtistDetailDTO.java
@@ -1,12 +1,14 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.ArtistEntity;
-import com.lalala.music.entity.ArtistType;
-import com.lalala.music.entity.GenderType;
 import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import com.lalala.music.entity.ArtistEntity;
+import com.lalala.music.entity.ArtistType;
+import com.lalala.music.entity.GenderType;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -19,9 +21,7 @@ public final class ArtistDetailDTO {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public static ArtistDetailDTO from(
-            ArtistEntity artist
-    ) {
+    public static ArtistDetailDTO from(ArtistEntity artist) {
         return new ArtistDetailDTO(
                 artist.getId(),
                 artist.getName(),
@@ -29,7 +29,6 @@ public final class ArtistDetailDTO {
                 artist.getType(),
                 artist.getAgency(),
                 artist.getCreatedAt(),
-                artist.getUpdatedAt()
-        );
+                artist.getUpdatedAt());
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/CreateAlbumRequestDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/CreateAlbumRequestDTO.java
@@ -1,11 +1,13 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.AlbumType;
 import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.lalala.music.entity.AlbumType;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/CreateArtistRequestDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/CreateArtistRequestDTO.java
@@ -1,11 +1,12 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.ArtistType;
-import com.lalala.music.entity.GenderType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.lalala.music.entity.ArtistType;
+import com.lalala.music.entity.GenderType;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/ExtractedMusicDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/ExtractedMusicDTO.java
@@ -1,0 +1,20 @@
+package com.lalala.music.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class ExtractedMusicDTO {
+    private String title;
+    private String artist;
+    private String album;
+    private String lyrics;
+    private Long playTime;
+
+    private byte[] coverData;
+    private String coverExtension;
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/FileDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/FileDTO.java
@@ -1,12 +1,12 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.FormatType;
-import com.lalala.music.entity.MusicFile;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
+
+import com.lalala.music.entity.FormatType;
+import com.lalala.music.entity.MusicFile;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -16,9 +16,6 @@ public class FileDTO {
     private FormatType formatType;
 
     public static FileDTO from(MusicFile musicFile) {
-        return new FileDTO(
-                musicFile.getFileUrl(),
-                musicFile.getFormatType()
-        );
+        return new FileDTO(musicFile.getFileUrl(), musicFile.getFormatType());
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/MusicDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/MusicDTO.java
@@ -1,13 +1,14 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.AlbumEntity;
-import com.lalala.music.entity.ArtistEntity;
-import com.lalala.music.entity.FormatType;
-import com.lalala.music.entity.MusicEntity;
 import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import com.lalala.music.entity.AlbumEntity;
+import com.lalala.music.entity.ArtistEntity;
+import com.lalala.music.entity.MusicEntity;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -21,11 +22,7 @@ public class MusicDTO {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public static MusicDTO from(
-            MusicEntity music,
-            AlbumEntity album,
-            ArtistEntity artist
-    ) {
+    public static MusicDTO from(MusicEntity music, AlbumEntity album, ArtistEntity artist) {
         return new MusicDTO(
                 music.getId(),
                 music.getTitle(),
@@ -34,7 +31,6 @@ public class MusicDTO {
                 FileDTO.from(music.getFile()),
                 ArtistDTO.from(artist),
                 music.getCreatedAt(),
-                music.getUpdatedAt()
-        );
+                music.getUpdatedAt());
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/MusicDetailDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/MusicDetailDTO.java
@@ -1,13 +1,14 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.AlbumEntity;
-import com.lalala.music.entity.ArtistEntity;
-import com.lalala.music.entity.MusicEntity;
 import java.time.LocalDateTime;
-import java.util.Set;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import com.lalala.music.entity.AlbumEntity;
+import com.lalala.music.entity.ArtistEntity;
+import com.lalala.music.entity.MusicEntity;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -22,11 +23,7 @@ public class MusicDetailDTO {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public static MusicDetailDTO from(
-            MusicEntity music,
-            ArtistEntity artist,
-            AlbumEntity album
-    ) {
+    public static MusicDetailDTO from(MusicEntity music, ArtistEntity artist, AlbumEntity album) {
         return new MusicDetailDTO(
                 music.getId(),
                 music.getTitle(),
@@ -34,11 +31,8 @@ public class MusicDetailDTO {
                 music.getLyrics(),
                 AlbumDTO.from(album, artist),
                 FileDTO.from(music.getFile()),
-                ParticipantsDetailDTO.from(
-                        artist
-                ),
+                ParticipantsDetailDTO.from(artist),
                 music.getCreatedAt(),
-                music.getUpdatedAt()
-        );
+                music.getUpdatedAt());
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/ParticipantsDetailDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/ParticipantsDetailDTO.java
@@ -1,19 +1,16 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.ArtistEntity;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import com.lalala.music.entity.ArtistEntity;
 
 @Getter
 @RequiredArgsConstructor
 public class ParticipantsDetailDTO {
     private final ArtistDTO artist;
 
-    public static ParticipantsDetailDTO from(
-            ArtistEntity artist
-    ) {
-        return new ParticipantsDetailDTO(
-                ArtistDTO.from(artist)
-        );
+    public static ParticipantsDetailDTO from(ArtistEntity artist) {
+        return new ParticipantsDetailDTO(ArtistDTO.from(artist));
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/ParticipantsRequestDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/ParticipantsRequestDTO.java
@@ -1,6 +1,5 @@
 package com.lalala.music.dto;
 
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/SuccessResponse.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/SuccessResponse.java
@@ -1,0 +1,26 @@
+package com.lalala.music.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class SuccessResponse<T> {
+    private int status;
+    private String code;
+    private String message;
+    private T data;
+
+    public static <T> SuccessResponse<T> from(HttpStatus status, String message, T data) {
+        return new SuccessResponse<>(
+                status.value(),
+                "0000", // 성공 코드
+                message,
+                data);
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/UpdateAlbumRequestDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/UpdateAlbumRequestDTO.java
@@ -1,11 +1,13 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.AlbumType;
 import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.lalala.music.entity.AlbumType;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/UpdateArtistRequestDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/UpdateArtistRequestDTO.java
@@ -1,11 +1,12 @@
 package com.lalala.music.dto;
 
-import com.lalala.music.entity.ArtistType;
-import com.lalala.music.entity.GenderType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.lalala.music.entity.ArtistType;
+import com.lalala.music.entity.GenderType;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/UploadResponseDTO.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/dto/UploadResponseDTO.java
@@ -1,0 +1,13 @@
+package com.lalala.music.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class UploadResponseDTO {
+    private String url;
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/AlbumEntity.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/AlbumEntity.java
@@ -1,5 +1,11 @@
 package com.lalala.music.entity;
 
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,10 +14,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "albums")
@@ -38,12 +40,7 @@ public class AlbumEntity extends BaseTimeEntity {
     @Column(name = "released_at", nullable = false, columnDefinition = "DATETIME default NOW()")
     LocalDateTime releasedAt;
 
-    public AlbumEntity(
-            String title,
-            String coverUrl,
-            AlbumType type,
-            LocalDateTime releasedAt
-    ) {
+    public AlbumEntity(String title, String coverUrl, AlbumType type, LocalDateTime releasedAt) {
         this.title = title;
         this.coverUrl = coverUrl;
         this.type = type;
@@ -54,12 +51,7 @@ public class AlbumEntity extends BaseTimeEntity {
         this.artistId = artistId;
     }
 
-    public void update(
-            String title,
-            String coverUrl,
-            AlbumType type,
-            LocalDateTime releasedAt
-    ) {
+    public void update(String title, String coverUrl, AlbumType type, LocalDateTime releasedAt) {
         this.title = title;
         this.coverUrl = coverUrl;
         this.type = type;

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/ArtistEntity.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/ArtistEntity.java
@@ -1,5 +1,9 @@
 package com.lalala.music.entity;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,9 +12,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "artists")
@@ -35,24 +36,14 @@ public class ArtistEntity extends BaseTimeEntity {
     @Column(nullable = false, length = 50, columnDefinition = "VARCHAR(50) default ''")
     String agency;
 
-    public ArtistEntity(
-            String name,
-            GenderType gender,
-            ArtistType type,
-            String agency
-    ) {
+    public ArtistEntity(String name, GenderType gender, ArtistType type, String agency) {
         this.name = name;
         this.gender = gender;
         this.type = type;
         this.agency = agency;
     }
 
-    public void update(
-            String name,
-            GenderType gender,
-            ArtistType type,
-            String agency
-    ) {
+    public void update(String name, GenderType gender, ArtistType type, String agency) {
         this.name = name;
         this.gender = gender;
         this.type = type;

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/ArtistType.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/ArtistType.java
@@ -3,4 +3,5 @@ package com.lalala.music.entity;
 public enum ArtistType {
     SOLO,
     GROUP,
+    NONE,
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/BaseTimeEntity.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/BaseTimeEntity.java
@@ -1,20 +1,21 @@
 package com.lalala.music.entity;
 
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+
 import lombok.Getter;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
 public abstract class BaseTimeEntity {
-    @CreatedDate
-    private LocalDateTime createdAt;
+    @CreatedDate private LocalDateTime createdAt;
 
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
+    @LastModifiedDate private LocalDateTime updatedAt;
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/GenderType.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/GenderType.java
@@ -4,4 +4,5 @@ public enum GenderType {
     MALE,
     FEMALE,
     MIX,
+    NONE,
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/MusicEntity.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/MusicEntity.java
@@ -1,5 +1,9 @@
 package com.lalala.music.entity;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -7,9 +11,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "musics")
@@ -35,24 +36,15 @@ public class MusicEntity extends BaseTimeEntity {
     @Column(name = "artist_id", nullable = false)
     Long artistId;
 
-    @Embedded
-    MusicFile file = new MusicFile();
+    @Embedded MusicFile file = new MusicFile();
 
-    public MusicEntity(
-            String title,
-            Short playTime,
-            String lyrics
-    ) {
+    public MusicEntity(String title, Short playTime, String lyrics) {
         this.title = title;
         this.playTime = playTime;
         this.lyrics = lyrics;
     }
 
-    public void update(
-            String title,
-            Short playTime,
-            String lyrics
-    ) {
+    public void update(String title, Short playTime, String lyrics) {
         this.title = title;
         this.playTime = playTime;
         this.lyrics = lyrics;

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/MusicFile.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/entity/MusicFile.java
@@ -1,13 +1,14 @@
 package com.lalala.music.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 
 @Embeddable
 @Getter
@@ -17,7 +18,11 @@ public class MusicFile {
     @Column(name = "file_url", nullable = false, columnDefinition = "VARCHAR(255) default ''")
     String fileUrl;
 
-    @Column(name = "format_type", nullable = false, length = 5, columnDefinition = "VARCHAR(5) default 'MP3'")
+    @Column(
+            name = "format_type",
+            nullable = false,
+            length = 5,
+            columnDefinition = "VARCHAR(5) default 'MP3'")
     @Enumerated(EnumType.STRING)
     FormatType formatType;
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/exception/BusinessException.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.lalala.music.exception;
+
+public class BusinessException extends RuntimeException {
+    private ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/exception/ErrorCode.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/exception/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.lalala.music.exception;
+
+import lombok.Getter;
+
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    // Common Exception
+    UNKNOWN_ERROR(HttpStatus.BAD_REQUEST, "0001", "알 수 없는 오류가 발생했습니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "0002", "잘못된 매개 변수입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "0003", "허용되지 않는 메소드입니다."),
+    HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "0004", "접근 권한이 없습니다."),
+    DATABASE_ERROR(HttpStatus.BAD_REQUEST, "0005", "데이터베이스가 응답하지 않습니다."),
+    DATABASE_UPDATE_FAILED(HttpStatus.BAD_REQUEST, "0006", "데이터베이스 업데이트에 실패했습니다."),
+
+    // 1000 ~ Music Exception
+    TEMP_DOWNLOAD_FAILED(HttpStatus.BAD_REQUEST, "1001", "임시 파일 다운로드에 실패했습니다."),
+    MUSIC_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "1002", "음원 업로드가 실패했습니다."),
+    INVALID_MP3_TAG(HttpStatus.BAD_REQUEST, "1003", "MP3 태그 버전을 찾을 수 없습니다."),
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(final HttpStatus status, final String code, final String message) {
+        this.status = status.value();
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/exception/ErrorResponse.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/exception/ErrorResponse.java
@@ -1,0 +1,87 @@
+package com.lalala.music.exception;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+    private String message;
+    private int status;
+    private List<FieldError> errors;
+    private String code;
+
+    private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+        this.message = code.getMessage();
+        this.status = code.getStatus();
+        this.errors = errors;
+        this.code = code.getCode();
+    }
+
+    private ErrorResponse(final ErrorCode code) {
+        this.message = code.getMessage();
+        this.status = code.getStatus();
+        this.code = code.getCode();
+        this.errors = new ArrayList<>();
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
+        return new ErrorResponse(code, errors);
+    }
+
+    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+        final String value = e.getValue() == null ? "" : e.getValue().toString();
+        final List<ErrorResponse.FieldError> errors =
+                ErrorResponse.FieldError.of(e.getName(), value, e.getErrorCode());
+        return new ErrorResponse(ErrorCode.INVALID_PARAMETER, errors);
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        private FieldError(final String field, final String value, final String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(final String field, final String value, final String reason) {
+            List<FieldError> fieldErrors = new ArrayList<>();
+            fieldErrors.add(new FieldError(field, value, reason));
+            return fieldErrors;
+        }
+
+        private static List<FieldError> of(final BindingResult bindingResult) {
+            final List<org.springframework.validation.FieldError> fieldErrors =
+                    bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(
+                            error ->
+                                    new FieldError(
+                                            error.getField(),
+                                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/exception/GlobalExceptionHandler.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/exception/GlobalExceptionHandler.java
@@ -1,0 +1,85 @@
+package com.lalala.music.exception;
+
+import java.nio.file.AccessDeniedException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+    /**
+     * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다. HttpMessageConverter 에서 등록한
+     * HttpMessageConverter binding 못할경우 발생 주로 @RequestBody, @RequestPart 어노테이션에서 발생
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e) {
+        log.error("handleMethodArgumentNotValidException", e);
+        final ErrorResponse response =
+                ErrorResponse.of(ErrorCode.INVALID_PARAMETER, e.getBindingResult());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * @ModelAttribut 으로 binding error 발생시 BindException 발생한다. ref
+     * https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args
+     */
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("handleBindException", e);
+        final ErrorResponse response =
+                ErrorResponse.of(ErrorCode.INVALID_PARAMETER, e.getBindingResult());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /** enum type 일치하지 않아 binding 못할 경우 발생 주로 @RequestParam enum으로 binding 못했을 경우 발생 */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        final ErrorResponse response = ErrorResponse.of(e);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /** 지원하지 않은 HTTP method 호출 할 경우 발생 */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    /** Authentication 객체가 필요한 권한을 보유하지 않은 경우 발생합 */
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("handleAccessDeniedException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
+        return new ResponseEntity<>(
+                response, HttpStatus.valueOf(ErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+        log.error("handleBusinessException", e);
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.UNKNOWN_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/exception/UploadFailedException.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/exception/UploadFailedException.java
@@ -1,0 +1,7 @@
+package com.lalala.music.exception;
+
+public class UploadFailedException extends BusinessException {
+    public UploadFailedException() {
+        super(ErrorCode.MUSIC_UPLOAD_FAILED);
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/listener/StartUpListener.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/listener/StartUpListener.java
@@ -1,0 +1,19 @@
+package com.lalala.music.listener;
+
+import java.io.File;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class StartUpListener {
+    @EventListener(ApplicationReadyEvent.class)
+    public void MakeTempDirectoryAfterStartUp() {
+        new File("temp/").mkdir();
+        log.info("임시 음원 파일을 받을 temp 폴더를 생성했습니다.");
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/repository/AlbumRepository.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/repository/AlbumRepository.java
@@ -1,7 +1,7 @@
 package com.lalala.music.repository;
 
-import com.lalala.music.entity.AlbumEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AlbumRepository extends JpaRepository<AlbumEntity, Long> {
-}
+import com.lalala.music.entity.AlbumEntity;
+
+public interface AlbumRepository extends JpaRepository<AlbumEntity, Long> {}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/repository/ArtistRepository.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/repository/ArtistRepository.java
@@ -1,8 +1,7 @@
 package com.lalala.music.repository;
 
-import com.lalala.music.entity.ArtistEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ArtistRepository extends JpaRepository<ArtistEntity, Long> {
-}
+import com.lalala.music.entity.ArtistEntity;
 
+public interface ArtistRepository extends JpaRepository<ArtistEntity, Long> {}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/repository/MusicRepository.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/repository/MusicRepository.java
@@ -1,8 +1,10 @@
 package com.lalala.music.repository;
 
-import com.lalala.music.entity.MusicEntity;
 import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lalala.music.entity.MusicEntity;
 
 public interface MusicRepository extends JpaRepository<MusicEntity, Long> {
     List<MusicEntity> findAllByAlbumId(Long albumId);

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/service/ArtistService.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/service/ArtistService.java
@@ -1,25 +1,9 @@
 package com.lalala.music.service;
 
-import com.lalala.music.dto.ArtistDTO;
-import com.lalala.music.dto.ArtistDetailDTO;
-import com.lalala.music.dto.CreateArtistRequestDTO;
-import com.lalala.music.dto.UpdateArtistRequestDTO;
-import com.lalala.music.entity.AlbumEntity;
-import com.lalala.music.entity.ArtistEntity;
-import com.lalala.music.entity.MusicEntity;
-import com.lalala.music.repository.AlbumRepository;
-import com.lalala.music.repository.ArtistRepository;
-import com.lalala.music.repository.MusicRepository;
-import com.lalala.music.util.ArtistUtils;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +11,16 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.lalala.music.dto.ArtistDTO;
+import com.lalala.music.dto.ArtistDetailDTO;
+import com.lalala.music.dto.CreateArtistRequestDTO;
+import com.lalala.music.dto.UpdateArtistRequestDTO;
+import com.lalala.music.entity.ArtistEntity;
+import com.lalala.music.repository.AlbumRepository;
+import com.lalala.music.repository.ArtistRepository;
+import com.lalala.music.repository.MusicRepository;
+import com.lalala.music.util.ArtistUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -38,45 +32,29 @@ public class ArtistService {
 
     @Transactional
     public ArtistDTO createArtist(CreateArtistRequestDTO request) {
-        ArtistEntity artist = new ArtistEntity(
-                request.getName(),
-                request.getGender(),
-                request.getType(),
-                request.getAgency()
-        );
+        ArtistEntity artist =
+                new ArtistEntity(
+                        request.getName(), request.getGender(), request.getType(), request.getAgency());
         artist = repository.save(artist);
         return ArtistDTO.from(artist);
     }
 
     public List<ArtistDTO> getArtists(int page, int pageSize) {
-        Pageable pageable = PageRequest.of(
-                page,
-                pageSize,
-                Sort.by(Direction.DESC, "id")
-        );
-        Page<ArtistDTO> artists = repository
-                .findAll(pageable)
-                .map(ArtistDTO::from);
+        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Direction.DESC, "id"));
+        Page<ArtistDTO> artists = repository.findAll(pageable).map(ArtistDTO::from);
         return artists.getContent();
     }
 
     public ArtistDetailDTO getArtist(Long id) {
         ArtistEntity artist = ArtistUtils.findById(id, repository);
 
-        return ArtistDetailDTO.from(
-                artist
-        );
+        return ArtistDetailDTO.from(artist);
     }
 
     @Transactional
     public ArtistDTO updateArtist(Long id, UpdateArtistRequestDTO request) {
         ArtistEntity artist = ArtistUtils.findById(id, repository);
-        artist.update(
-                request.getName(),
-                request.getGender(),
-                request.getType(),
-                request.getAgency()
-        );
+        artist.update(request.getName(), request.getGender(), request.getType(), request.getAgency());
         return ArtistDTO.from(artist);
     }
 

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/service/MusicExtractorService.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/service/MusicExtractorService.java
@@ -1,0 +1,95 @@
+package com.lalala.music.service;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.lalala.music.dto.ExtractedMusicDTO;
+import com.lalala.music.exception.BusinessException;
+import com.lalala.music.exception.ErrorCode;
+import com.mpatric.mp3agic.ID3v1;
+import com.mpatric.mp3agic.ID3v2;
+import com.mpatric.mp3agic.InvalidDataException;
+import com.mpatric.mp3agic.Mp3File;
+import com.mpatric.mp3agic.UnsupportedTagException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MusicExtractorService {
+    private final ArtistService artistService;
+    private final MusicService musicService;
+    private final AlbumService albumService;
+
+    public File downloadToTemp(MultipartFile multipart) {
+        Objects.requireNonNull(multipart.getOriginalFilename());
+
+        log.info(
+                "음원 임시 파일을 다운로드 - "
+                        + multipart.getOriginalFilename()
+                        + " ( "
+                        + multipart.getContentType()
+                        + " )");
+        try {
+            Path destination =
+                    Paths.get("temp").resolve(multipart.getOriginalFilename()).normalize().toAbsolutePath();
+            InputStream bufferedInputStream = new BufferedInputStream(multipart.getInputStream());
+            Files.copy(bufferedInputStream, destination, StandardCopyOption.REPLACE_EXISTING);
+            return new File(destination.toUri());
+        } catch (IOException exception) {
+            log.error("음원 임시 파일 다운로드 예외 발생", exception);
+            throw new BusinessException(ErrorCode.TEMP_DOWNLOAD_FAILED);
+        }
+    }
+
+    public ExtractedMusicDTO extract(File file) {
+        log.info("MP3 Extracting - " + file.getName());
+
+        try {
+            Mp3File mp3file = new Mp3File(file);
+
+            if (mp3file.hasId3v1Tag()) {
+                ID3v1 id3v1Tag = mp3file.getId3v1Tag();
+                return new ExtractedMusicDTO(
+                        id3v1Tag.getTitle(),
+                        id3v1Tag.getArtist(),
+                        id3v1Tag.getAlbum(),
+                        "",
+                        mp3file.getLengthInSeconds(),
+                        null,
+                        null);
+            } else if (mp3file.hasId3v2Tag()) {
+                ID3v2 id3v2Tag = mp3file.getId3v2Tag();
+
+                String mimeType = id3v2Tag.getAlbumImageMimeType();
+                String extension = mimeType.split("/")[1];
+
+                return new ExtractedMusicDTO(
+                        id3v2Tag.getTitle(),
+                        id3v2Tag.getArtist(),
+                        id3v2Tag.getAlbum(),
+                        id3v2Tag.getLyrics() == null ? "" : id3v2Tag.getLyrics(),
+                        mp3file.getLengthInSeconds(),
+                        id3v2Tag.getAlbumImage(),
+                        extension);
+            } else {
+                throw new BusinessException(ErrorCode.INVALID_MP3_TAG);
+            }
+        } catch (IOException | UnsupportedTagException | InvalidDataException exception) {
+            log.error("MP3 Load Error", exception);
+            throw new BusinessException(ErrorCode.INVALID_MP3_TAG);
+        }
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/service/MusicService.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/service/MusicService.java
@@ -1,5 +1,19 @@
 package com.lalala.music.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.lalala.music.dto.CreateMusicRequestDTO;
 import com.lalala.music.dto.MusicDTO;
 import com.lalala.music.dto.MusicDetailDTO;
@@ -14,19 +28,6 @@ import com.lalala.music.repository.MusicRepository;
 import com.lalala.music.util.AlbumUtils;
 import com.lalala.music.util.ArtistUtils;
 import com.lalala.music.util.MusicUtils;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -39,71 +40,43 @@ public class MusicService {
     @Transactional
     public MusicDetailDTO createMusic(CreateMusicRequestDTO request) {
         AlbumEntity album = AlbumUtils.findById(request.getAlbumId(), albumRepository);
-        ArtistEntity artist = ArtistUtils.findById(request.getParticipants().getArtistId(), artistRepository);
+        ArtistEntity artist =
+                ArtistUtils.findById(request.getParticipants().getArtistId(), artistRepository);
 
-        final MusicEntity music = new MusicEntity(
-                request.getTitle(),
-                request.getPlayTime(),
-                request.getLyrics()
-        );
+        final MusicEntity music =
+                new MusicEntity(request.getTitle(), request.getPlayTime(), request.getLyrics());
 
-        music.updateFile(new MusicFile(
-                request.getFile().getFileUrl(),
-                request.getFile().getFormatType()
-        ));
+        music.updateFile(
+                new MusicFile(request.getFile().getFileUrl(), request.getFile().getFormatType()));
 
         music.updateAlbum(request.getAlbumId());
         music.updateArtist(request.getParticipants().getArtistId());
 
         repository.save(music);
 
-        return MusicDetailDTO.from(
-                music,
-                artist,
-                album
-        );
+        return MusicDetailDTO.from(music, artist, album);
     }
 
     public List<MusicDTO> getMusics(int page, int pageSize) {
-        Pageable pageable = PageRequest.of(
-                page,
-                pageSize,
-                Sort.by(Direction.DESC, "id")
-        );
-        List<MusicEntity> musics = repository
-                .findAll(pageable)
-                .getContent();
+        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Direction.DESC, "id"));
+        List<MusicEntity> musics = repository.findAll(pageable).getContent();
 
-        List<Long> artistIds = musics.stream()
-                .map(MusicEntity::getArtistId)
-                .toList();
-        Map<Long, ArtistEntity> artistMap = artistRepository.findAllById(artistIds)
-                .stream()
-                .collect(
-                        Collectors.toMap(
-                                ArtistEntity::getId,
-                                Function.identity()
-                        )
-                );
+        List<Long> artistIds = musics.stream().map(MusicEntity::getArtistId).toList();
+        Map<Long, ArtistEntity> artistMap =
+                artistRepository.findAllById(artistIds).stream()
+                        .collect(Collectors.toMap(ArtistEntity::getId, Function.identity()));
 
-        List<Long> albumIds = musics.stream()
-                .map(MusicEntity::getAlbumId)
-                .toList();
-        Map<Long, AlbumEntity> albumMap = albumRepository.findAllById(albumIds)
-                .stream()
-                .collect(
-                        Collectors.toMap(
-                                AlbumEntity::getId,
-                                Function.identity()
-                        )
-                );
+        List<Long> albumIds = musics.stream().map(MusicEntity::getAlbumId).toList();
+        Map<Long, AlbumEntity> albumMap =
+                albumRepository.findAllById(albumIds).stream()
+                        .collect(Collectors.toMap(AlbumEntity::getId, Function.identity()));
 
         return musics.stream()
-                .map(music -> MusicDTO.from(
-                            music,
-                            albumMap.get(music.getAlbumId()),
-                            artistMap.get(music.getAlbumId())
-                )).toList();
+                .map(
+                        music ->
+                                MusicDTO.from(
+                                        music, albumMap.get(music.getAlbumId()), artistMap.get(music.getArtistId())))
+                .toList();
     }
 
     public MusicDetailDTO getMusic(long id) {
@@ -111,40 +84,27 @@ public class MusicService {
         AlbumEntity album = AlbumUtils.findById(music.getAlbumId(), albumRepository);
         ArtistEntity artist = ArtistUtils.findById(music.getArtistId(), artistRepository);
 
-        return MusicDetailDTO.from(
-                music,
-                artist,
-                album
-        );
+        return MusicDetailDTO.from(music, artist, album);
     }
 
     @Transactional
     public MusicDetailDTO updateMusic(Long id, UpdateMusicRequestDTO request) {
         AlbumEntity album = AlbumUtils.findById(request.getAlbumId(), albumRepository);
-        ArtistEntity artist = ArtistUtils.findById(request.getParticipants().getArtistId(), artistRepository);
+        ArtistEntity artist =
+                ArtistUtils.findById(request.getParticipants().getArtistId(), artistRepository);
         MusicEntity music = MusicUtils.findById(id, repository);
 
-        music.update(
-                request.getTitle(),
-                request.getPlayTime(),
-                request.getLyrics()
-        );
+        music.update(request.getTitle(), request.getPlayTime(), request.getLyrics());
 
-        music.updateFile(new MusicFile(
-                request.getFile().getFileUrl(),
-                request.getFile().getFormatType()
-        ));
+        music.updateFile(
+                new MusicFile(request.getFile().getFileUrl(), request.getFile().getFormatType()));
 
         music.updateAlbum(request.getAlbumId());
         music.updateArtist(request.getParticipants().getArtistId());
 
         repository.save(music);
 
-        return MusicDetailDTO.from(
-                music,
-                artist,
-                album
-        );
+        return MusicDetailDTO.from(music, artist, album);
     }
 
     @Transactional
@@ -155,10 +115,6 @@ public class MusicService {
 
         repository.delete(music);
 
-        return MusicDetailDTO.from(
-                music,
-                artist,
-                album
-        );
+        return MusicDetailDTO.from(music, artist, album);
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/service/MusicUploaderService.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/service/MusicUploaderService.java
@@ -1,0 +1,162 @@
+package com.lalala.music.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.lalala.music.dto.AlbumDetailDTO;
+import com.lalala.music.dto.ArtistDTO;
+import com.lalala.music.dto.CreateAlbumRequestDTO;
+import com.lalala.music.dto.CreateArtistRequestDTO;
+import com.lalala.music.dto.CreateMusicRequestDTO;
+import com.lalala.music.dto.ExtractedMusicDTO;
+import com.lalala.music.dto.FileDTO;
+import com.lalala.music.dto.MusicDetailDTO;
+import com.lalala.music.dto.ParticipantsRequestDTO;
+import com.lalala.music.dto.UploadResponseDTO;
+import com.lalala.music.entity.AlbumType;
+import com.lalala.music.entity.ArtistType;
+import com.lalala.music.entity.FormatType;
+import com.lalala.music.entity.GenderType;
+import com.lalala.music.entity.MusicFile;
+import com.lalala.music.exception.UploadFailedException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MusicUploaderService {
+    @Qualifier("uploaderClient")
+    private final RestClient restClient;
+
+    private final MusicExtractorService extractorService;
+    private final MusicService musicService;
+    private final ArtistService artistService;
+    private final AlbumService albumService;
+
+    @Transactional
+    public MusicDetailDTO upload(MultipartFile file) {
+        File downloadFile = extractorService.downloadToTemp(file);
+
+        ExtractedMusicDTO extractedMusic = extractorService.extract(downloadFile);
+
+        UploadResponseDTO imageResponse =
+                this.uploadImage(extractedMusic.getCoverData(), extractedMusic.getCoverExtension());
+        UploadResponseDTO musicResponse = this.uploadMusic(file);
+
+        ArtistDTO artist =
+                artistService.createArtist(
+                        new CreateArtistRequestDTO(
+                                extractedMusic.getArtist(), GenderType.NONE, ArtistType.NONE, "NCS"));
+
+        AlbumDetailDTO album =
+                albumService.createAlbum(
+                        new CreateAlbumRequestDTO(
+                                extractedMusic.getAlbum(),
+                                imageResponse.getUrl(),
+                                AlbumType.SINGLE,
+                                LocalDateTime.now(),
+                                artist.getId()));
+
+        return musicService.createMusic(
+                new CreateMusicRequestDTO(
+                        extractedMusic.getTitle(),
+                        extractedMusic.getPlayTime().shortValue(),
+                        extractedMusic.getLyrics(),
+                        album.getId(),
+                        FileDTO.from(new MusicFile(musicResponse.getUrl(), FormatType.MP3)),
+                        new ParticipantsRequestDTO(artist.getId())));
+    }
+
+    public UploadResponseDTO uploadImage(byte[] imageData, String extension) {
+        if (imageData == null || extension == null) {
+            return new UploadResponseDTO(null);
+        }
+
+        ByteArrayResource imageResource =
+                new ByteArrayResource(imageData) {
+                    @Override
+                    public String getFilename() {
+                        return UUID.randomUUID() + "." + extension;
+                    }
+                };
+
+        MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
+        parts.add("upload", imageResource);
+
+        return restClient
+                .post()
+                .uri("/upload")
+                .headers(httpHeaders -> httpHeaders.setContentType(MediaType.MULTIPART_FORM_DATA))
+                .body(parts)
+                .retrieve()
+                .onStatus(
+                        HttpStatusCode::is4xxClientError,
+                        (req, res) -> {
+                            log.error("앨범커버 업로드 실패(4xx) - " + imageResource.getFilename());
+                            throw new UploadFailedException();
+                        })
+                .onStatus(
+                        HttpStatusCode::is5xxServerError,
+                        (req, res) -> {
+                            log.error("앨범커버 업로드 실패(5xx) - " + imageResource.getFilename());
+                            throw new UploadFailedException();
+                        })
+                .body(UploadResponseDTO.class);
+    }
+
+    public UploadResponseDTO uploadMusic(MultipartFile file) {
+        Objects.requireNonNull(file);
+
+        try {
+            ByteArrayResource musicResource =
+                    new ByteArrayResource(file.getBytes()) {
+                        @Override
+                        public String getFilename() {
+                            return file.getOriginalFilename();
+                        }
+                    };
+
+            MultiValueMap<String, Object> parts = new LinkedMultiValueMap<>();
+            parts.add("upload", musicResource);
+
+            return restClient
+                    .post()
+                    .uri("/upload")
+                    .headers(httpHeaders -> httpHeaders.setContentType(MediaType.MULTIPART_FORM_DATA))
+                    .body(parts)
+                    .retrieve()
+                    .onStatus(
+                            HttpStatusCode::is4xxClientError,
+                            (req, res) -> {
+                                log.error("음원 업로드 실패(4xx) - " + musicResource.getFilename());
+                                throw new UploadFailedException();
+                            })
+                    .onStatus(
+                            HttpStatusCode::is5xxServerError,
+                            (req, res) -> {
+                                log.error("음원 업로드 실패(5xx) - " + musicResource.getFilename());
+                                throw new UploadFailedException();
+                            })
+                    .body(UploadResponseDTO.class);
+        } catch (IOException exception) {
+            log.error("음원 업로드 실패", exception);
+            throw new UploadFailedException();
+        }
+    }
+}

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/util/AlbumUtils.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/util/AlbumUtils.java
@@ -1,14 +1,14 @@
 package com.lalala.music.util;
 
-import com.lalala.music.entity.AlbumEntity;
-import com.lalala.music.repository.AlbumRepository;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import com.lalala.music.entity.AlbumEntity;
+import com.lalala.music.repository.AlbumRepository;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AlbumUtils {
     public static AlbumEntity findById(Long id, AlbumRepository repository) {
-        return repository.findById(id)
-                .orElseThrow(() -> new RuntimeException("앨범을 조회할 수 없습니다."));
+        return repository.findById(id).orElseThrow(() -> new RuntimeException("앨범을 조회할 수 없습니다."));
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/util/ArtistUtils.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/util/ArtistUtils.java
@@ -1,14 +1,14 @@
 package com.lalala.music.util;
 
-import com.lalala.music.entity.ArtistEntity;
-import com.lalala.music.repository.ArtistRepository;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import com.lalala.music.entity.ArtistEntity;
+import com.lalala.music.repository.ArtistRepository;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ArtistUtils {
     public static ArtistEntity findById(Long id, ArtistRepository repository) {
-        return repository.findById(id)
-                .orElseThrow(() -> new RuntimeException("아티스트를 조회할 수 없습니다."));
+        return repository.findById(id).orElseThrow(() -> new RuntimeException("아티스트를 조회할 수 없습니다."));
     }
 }

--- a/src/backend/music-server/music-api/src/main/java/com/lalala/music/util/MusicUtils.java
+++ b/src/backend/music-server/music-api/src/main/java/com/lalala/music/util/MusicUtils.java
@@ -1,14 +1,14 @@
 package com.lalala.music.util;
 
-import com.lalala.music.entity.MusicEntity;
-import com.lalala.music.repository.MusicRepository;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import com.lalala.music.entity.MusicEntity;
+import com.lalala.music.repository.MusicRepository;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MusicUtils {
     public static MusicEntity findById(Long id, MusicRepository repository) {
-        return repository.findById(id)
-                .orElseThrow(() -> new RuntimeException("음원을 조회할 수 없습니다."));
+        return repository.findById(id).orElseThrow(() -> new RuntimeException("음원을 조회할 수 없습니다."));
     }
 }

--- a/src/backend/music-server/music-api/src/main/resources/application-docker.yml
+++ b/src/backend/music-server/music-api/src/main/resources/application-docker.yml
@@ -4,7 +4,7 @@ server:
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: "jdbc:mysql://localhost:24100/music?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul"
+    url: "jdbc:mysql://music-mysql:3306/music?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul"
     username: root
     password: admin
 

--- a/src/backend/music-server/music-api/src/test/java/com/lalala/music/MusicApplicationTests.java
+++ b/src/backend/music-server/music-api/src/test/java/com/lalala/music/MusicApplicationTests.java
@@ -1,13 +1,12 @@
 package com.lalala.music;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import org.junit.jupiter.api.Test;
 
 @SpringBootTest
 class MusicApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {}
 }

--- a/src/backend/music-uploader-server/docker-compose.yml
+++ b/src/backend/music-uploader-server/docker-compose.yml
@@ -6,8 +6,15 @@ services:
       context: .
       dockerfile: ./Dockerfile
     environment:
-      - STORAGE_URL=http://fileserver-app:30000
+      - STORAGE_URL=http://fileserver-app
     ports:
       - "25000:3000"
     volumes:
       - ./:/app/
+    networks:
+      - lalala-network
+
+networks:
+  lalala-network:
+    driver: bridge
+    external: true

--- a/src/backend/music-uploader-server/docker-compose.yml
+++ b/src/backend/music-uploader-server/docker-compose.yml
@@ -1,12 +1,12 @@
 version: "3.9"
 
 services:
-  app:
+  music-uploader-app:
     build:
       context: .
       dockerfile: ./Dockerfile
     environment:
-      - STORAGE_UPLOAD_URL=http://host.docker.internal:20000/upload
+      - STORAGE_URL=http://fileserver-app:30000
     ports:
       - "25000:3000"
     volumes:

--- a/src/backend/music-uploader-server/src/plugins/dotenv.ts
+++ b/src/backend/music-uploader-server/src/plugins/dotenv.ts
@@ -4,11 +4,11 @@ import fastifyEnv, { FastifyEnvOptions } from "@fastify/env";
 export default fp<FastifyEnvOptions>(async (fastify) => {
   const schema = {
     type: "object",
-    required: ["STORAGE_UPLOAD_URL"],
+    required: ["STORAGE_URL"],
     properties: {
-      STORAGE_UPLOAD_URL: {
+      STORAGE_URL: {
         type: "string",
-        default: "http://localhost:20000/upload",
+        default: "http://localhost:30000",
       },
     },
   };
@@ -23,7 +23,7 @@ export default fp<FastifyEnvOptions>(async (fastify) => {
 declare module "fastify" {
   export interface FastifyInstance {
     config: {
-      STORAGE_UPLOAD_URL: string;
+      STORAGE_URL: string;
     };
   }
 }

--- a/src/backend/storage-server/docker-compose.yml
+++ b/src/backend/storage-server/docker-compose.yml
@@ -11,12 +11,14 @@ services:
     env_file:
       - .env
     networks:
-      - backend
+      - lalala-network
     volumes:
       - static-data:/resources
 
 networks:
-  backend:
+  lalala-network:
+    driver: bridge
+    external: true
 
 volumes:
   static-data:

--- a/src/backend/storage-server/main.go
+++ b/src/backend/storage-server/main.go
@@ -89,15 +89,17 @@ func handleMusicStaticFiles(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		audioFile, err := os.ReadFile("./resources/" + resourceName)
+		file, err := os.ReadFile("./resources/" + resourceName)
 		if err != nil {
 			logger.Error(err.Error())
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 
+		mimeType := http.DetectContentType(file)
+
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Content-Type", "audio/mpeg")
+		w.Header().Set("Content-Type", mimeType)
 
 		etag := fmt.Sprintf("%x", md5.Sum([]byte(resourceName)))
 		w.Header().Set("Cache-Control", "public, max-age=600")
@@ -111,7 +113,7 @@ func handleMusicStaticFiles(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		audioChunks := bytes.NewBuffer(audioFile)
+		audioChunks := bytes.NewBuffer(file)
 		if _, err := audioChunks.WriteTo(w); err != nil {
 			logger.Warn(err.Error())
 		}

--- a/src/backend/streaming-server/docker-compose.yml
+++ b/src/backend/streaming-server/docker-compose.yml
@@ -1,19 +1,20 @@
 version: '3.9'
 
 services:
-  app:
-    container_name: streaming-server
+  streaming-app:
     ports:
       - "22000:22000"
     build:
       context: .
       dockerfile: Dockerfile
     environment:
-      - client.endpoint.music=http://host.docker.internal:24000
-      - client.endpoint.storage=http://host.docker.internal:30000
+      - client.endpoint.music=http://music-app:24000
+      - client.endpoint.storage=http://music-uploader-app:30000
     restart: always
     networks:
-      - streaming-network
+      - lalala-network
 
 networks:
-  streaming-network:
+  lalala-network:
+    driver: bridge
+    external: true

--- a/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/dto/AlbumType.kt
+++ b/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/dto/AlbumType.kt
@@ -3,4 +3,5 @@ package com.lalala.streaming.dto
 enum class AlbumType {
     SINGLE,
     REGULAR,
+    NONE,
 }

--- a/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/dto/ArtistType.kt
+++ b/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/dto/ArtistType.kt
@@ -3,4 +3,5 @@ package com.lalala.streaming.dto
 enum class ArtistType {
     SOLO,
     GROUP,
+    NONE,
 }

--- a/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/dto/GenderType.kt
+++ b/src/backend/streaming-server/src/main/kotlin/com/lalala/streaming/dto/GenderType.kt
@@ -4,4 +4,5 @@ enum class GenderType {
     MALE,
     FEMALE,
     MIX,
+    NONE,
 }

--- a/src/infra/start.sh
+++ b/src/infra/start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+docker network create --driver bridge lalala-network
+
 cd "../backend/"
 
 BACKEND_PWD=`pwd`
@@ -8,6 +10,7 @@ SERVER_ORDER=(
     "storage-server"
     "music-server"
     "streaming-server"
+    "music-uploader-server"
 )
 
 echo "$BACKEND_PWD"


### PR DESCRIPTION
## Related Issue

close #52 

## Changes

- 음원 서버에 음원 업로드 기능 추가
  - 임시 폴더에 음원 파일 저장
  - 음원 분석하여 DB 적재
  - 이미지 / 음원파일 업로더 서버에 전달하여 스토리지 서버에 저장
- 시작 시 임시 폴더 청소
- 앨범 타입 / 아티스트 타입 / 그룹 타입에 NONE 타입 추가 (현재 사용하지 않음)

## Screenshots

<!-- PR의 변경사항을 보여주는 스크린샷. 필요시 추가하세요. -->

## To Reviewer

<!-- 리뷰어에게 별도로 전달하고 싶은 내용이 있다면 입력하세요. -->

## Additional Context(optional)

<!-- 추가적인 문맥: 레퍼런스, 종속성 변경 등 PR과는 직접적으로 관련되지 않은 정보를 입력하세요. -->

## How Has This Been Tested?

<!-- PR이 동작하는지 확인하기 위한 테스트 방법 및 케이스를 상세하게 설명해주세요. -->

## Checklist

<!-- PR 등록 전 확인해 주세요! -->

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
