### PR TITLE
Feat/#72 검색 서버를 유레카 서버에 등록합니다.

### DIFF
--- a/src/backend/search-server/backend/src/main.py
+++ b/src/backend/search-server/backend/src/main.py
@@ -1,5 +1,17 @@
+import py_eureka_client.eureka_client as eureka_client
 from fastapi import FastAPI
-from .api import client, indexing, query;
+from .api import client, indexing, query
+
+# eureka_client 에서 nested async await 지원 위한 라이브러리
+import nest_asyncio
+nest_asyncio.apply()
+
+# TODO: host env 으로 받기
+eureka_client.init(
+    eureka_server="http://localhost:34100",
+    app_name="SEARCH-SERVER",
+    instance_port=20000
+)
 
 app = FastAPI()
 

--- a/src/backend/search-server/docker-compose-hub.yml
+++ b/src/backend/search-server/docker-compose-hub.yml
@@ -10,9 +10,11 @@ services:
       - PORT=20000
       - ENV=develop
       - ELASTICSEARCH_HOST=elasticsearch
+      - EUREKA_HOST=http://discovery-app:34100
     depends_on:
       - elasticsearch
     networks:
+      - default
       - lalala-network
 
   elasticsearch:

--- a/src/backend/search-server/docker-compose.yml
+++ b/src/backend/search-server/docker-compose.yml
@@ -12,9 +12,11 @@ services:
       - PORT=20000
       - ENV=develop
       - ELASTICSEARCH_HOST=elasticsearch
+      - EUREKA_HOST=http://localhost:34100
     depends_on:
       - elasticsearch
     networks:
+      - default
       - lalala-network
 
   elasticsearch:

--- a/src/backend/search-server/requirements.txt
+++ b/src/backend/search-server/requirements.txt
@@ -2,4 +2,5 @@ fastapi
 uvicorn
 httpx
 elasticsearch
+nest_asyncio
 py_eureka_client

--- a/src/backend/search-server/requirements.txt
+++ b/src/backend/search-server/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 elasticsearch
+py_eureka_client


### PR DESCRIPTION
## Related Issue

close #72 

## Changes

- `py_eureka_client` 라이브러리 추가
- localhost 디스커버리 서버에 연동

## Screenshots

<!-- PR의 변경사항을 보여주는 스크린샷. 필요시 추가하세요. -->

http://localhost:34100 유레카 서버에서 아래처럼 확인 가능

![스크린샷 2024-02-15 오전 10 37 18](https://github.com/sgdevcamp2023/sgwannabe/assets/16275188/77083128-f724-4a17-88b6-6edde841a038)

## To Reviewer

<!-- 리뷰어에게 별도로 전달하고 싶은 내용이 있다면 입력하세요. -->

## Additional Context(optional)

<!-- 추가적인 문맥: 레퍼런스, 종속성 변경 등 PR과는 직접적으로 관련되지 않은 정보를 입력하세요. -->

- `py_eureka_client` 라이브러리에서 사용하는 async 지원을 위해 nest_asyncio 라이브러리 추가

## How Has This Been Tested?

<!-- PR이 동작하는지 확인하기 위한 테스트 방법 및 케이스를 상세하게 설명해주세요. -->

아래 명령어로 실행하고 http://localhost:34100 유레카 서버에서 확인
```bash
uvicorn backend.src.main:app --host 0.0.0.0 --port 20000
```

## Checklist

<!-- PR 등록 전 확인해 주세요! -->

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
