### PR TITLE
refactor: access token 전달 방식 변경

### DIFF
--- a/src/backend/auth-server/src/main/java/com/lalala/auth/config/jwt/JwtUtils.java
+++ b/src/backend/auth-server/src/main/java/com/lalala/auth/config/jwt/JwtUtils.java
@@ -52,9 +52,14 @@ public class JwtUtils {
         return Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey));
     }
 
-    /** 클라이언트 http cookie 관리 */
-    public ResponseCookie generateAccessJwtCookie(User user) {
-        String jwt = generateAccessTokenFromId(String.valueOf(user.getId()));
+    /**
+     * 클라이언트 http cookie 관리
+     */
+    public String generateAccessJwt(User user) {
+        return generateAccessTokenFromId(String.valueOf(user.getId()));
+    }
+
+    public ResponseCookie generateAccessJwtCookie(String jwt) {
         return generateCookie(jwtAccessCookie, jwt, "/");
     }
 

--- a/src/backend/auth-server/src/main/java/com/lalala/auth/service/AuthService.java
+++ b/src/backend/auth-server/src/main/java/com/lalala/auth/service/AuthService.java
@@ -46,7 +46,9 @@ public class AuthService {
             throw new BusinessException(ErrorCode.LOGIN_FAILED);
         }
 
-        ResponseCookie jwtAccessCookie = jwtUtils.generateAccessJwtCookie(user);
+        String jwtAccess = jwtUtils.generateAccessJwt(user);
+        ResponseCookie jwtAccessCookie = jwtUtils.generateAccessJwtCookie(jwtAccess);
+
 
         String refreshToken = jwtUtils.generateRefreshToken(String.valueOf(user.getId()));
 
@@ -62,7 +64,7 @@ public class AuthService {
                         UserAndTokenResponse.builder()
                                 .id(user.getId())
                                 .nickname(user.getNickname())
-                                .access_token(jwtAccessCookie.toString())
+                                .access_token(jwtAccess)
                                 .refresh_token(refreshToken)
                                 .build());
     }
@@ -116,7 +118,8 @@ public class AuthService {
         }
 
 
-        ResponseCookie jwtAccessCookie = jwtUtils.generateAccessJwtCookie(user);
+        String jwtAccess = jwtUtils.generateAccessJwt(user);
+        ResponseCookie jwtAccessCookie = jwtUtils.generateAccessJwtCookie(jwtAccess);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, jwtAccessCookie.toString())
@@ -124,7 +127,7 @@ public class AuthService {
                         UserAndTokenResponse.builder()
                                 .id(user.getId())
                                 .nickname(user.getNickname())
-                                .access_token(jwtAccessCookie.toString())
+                                .access_token(jwtAccess)
                                 .refresh_token(request.refreshToken())
                                 .build());
     }


### PR DESCRIPTION
## Related Issue

<!-- 관련 이슈를 링크해 주세요. 이를 통해 해당 PR과 연결된 문제를 명확하게 할 수 있습니다. -->

## Changes

- 프론트엔드에서 토큰을 받을때 쿠키에는 부가 정보가 포함되어 있어 response body에 토큰 string의 정보만 뿌리도록 변경했습니다.
```
soy-access-jwt=eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzA4MzkxMzI3LCJleHAiOjE3MDgzOTQzMjd9.eXNMLOPgkewZtpsHs_zkys1zdLSd2kATR_WvWlFsUVC66v0k3a150P1jtK8I9alrUEFxU2cKV5zvy7LhWgGeDw; Path=/; Max-Age=86400; Expires=Wed, 21 Feb 2024 01:08:47 GMT; HttpOnly
```

## Screenshots

<!-- PR의 변경사항을 보여주는 스크린샷. 필요시 추가하세요. -->

## To Reviewer

<!-- 리뷰어에게 별도로 전달하고 싶은 내용이 있다면 입력하세요. -->

## Additional Context(optional)

<!-- 추가적인 문맥: 레퍼런스, 종속성 변경 등 PR과는 직접적으로 관련되지 않은 정보를 입력하세요. -->

## How Has This Been Tested?

<!-- PR이 동작하는지 확인하기 위한 테스트 방법 및 케이스를 상세하게 설명해주세요. -->

## Checklist

<!-- PR 등록 전 확인해 주세요! -->

- [ ] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [ ] PR에 대해 구체적으로 설명이 되어있는가
