### PR TITLE
feat: 4개 초과 채팅방 참여 요청시 가장 오래된 채팅방 퇴장 로직 추가

### DIFF
--- a/src/backend/chatting-server/src/main/java/chattingserver/service/ChatMessageService.java
+++ b/src/backend/chatting-server/src/main/java/chattingserver/service/ChatMessageService.java
@@ -91,11 +91,21 @@ public class ChatMessageService {
 
     @Transactional
     public ChatMessageDto join(ChatMessageDto chatMessageDto) {
+
+        List<Room> roomList = roomRepository.findJoinedRoomsByUid(chatMessageDto.getSenderId());
+        if (roomList.size() == 4) {
+            log.info("참여 가능한 채팅방 수 초과. 가장 오래된 채팅방에서 퇴장합니다.");
+            String exitedRoomId = roomList.get(3).getId();
+            roomRepository.exitRoom(exitedRoomId, chatMessageDto.getSenderId());
+            log.info("가장 오래된 방 나가기 성공 uid={}, roomId={}", chatMessageDto.getSenderId(), exitedRoomId);
+        }
+
         try {
             Optional<Room> optionalRoom = roomRepository.findById(chatMessageDto.getRoomId());
             if (optionalRoom.isEmpty()) {
                 throw new BusinessException("존재하지 않는 채팅방입니다. 채팅방 id=" + chatMessageDto.getRoomId(), ErrorCode.UNKNOWN_ERROR);
             }
+
 
             Room room = optionalRoom.get();
 


### PR DESCRIPTION
## Related Issue

#70 

## Changes

4개 초과 채팅방 참여 요청시 가장 오래된 채팅방 퇴장 로직 추가

## Screenshots

.

## To Reviewer

```java
@Transactional
    public ChatMessageDto join(ChatMessageDto chatMessageDto) {

        List<Room> roomList = roomRepository.findJoinedRoomsByUid(chatMessageDto.getSenderId());
        if (roomList.size() == 4) {
            log.info("참여 가능한 채팅방 수 초과. 가장 오래된 채팅방에서 퇴장합니다.");
            String exitedRoomId = roomList.get(3).getId();
            roomRepository.exitRoom(exitedRoomId, chatMessageDto.getSenderId());
            log.info("가장 오래된 방 나가기 성공 uid={}, roomId={}", chatMessageDto.getSenderId(), exitedRoomId);
        }
```

## Additional Context(optional)

현재 로컬 웹소켓 연결이 네트워크 연결로 안되어서 테스트하지 못했습니다.

## How Has This Been Tested?

.

## Checklist

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
